### PR TITLE
feat: 🎸 Removed SPReg role

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,9 +43,6 @@
 [submodule "cesnet.mariadb"]
 	path = cesnet.mariadb
 	url = https://github.com/CESNET/ansible-role-mariadb.git
-[submodule "cesnet.spreg"]
-	path = cesnet.spreg
-	url = https://github.com/CESNET/ansible-role-spreg.git
 [submodule "cesnet.certbot_certs"]
 	path = cesnet.certbot_certs
 	url = https://github.com/CESNET/ansible-role-certbot-certs.git


### PR DESCRIPTION
Role will be archived from its original repository and merged directly
into the SPReg playook. This role is specific for the SPReg playbook and
it does not make further sense to have it as a shared role.

BREAKING CHANGE: 🧨 Removed SPReg role